### PR TITLE
13 patch song endpoint am aq

### DIFF
--- a/server.js
+++ b/server.js
@@ -72,3 +72,25 @@ app.get('/api/v1/songs/:id', (request, response) => {
       response.status(500).json({ error });
     });
 });
+
+// PATCH SONG
+
+app.patch('/api/v1/songs/:id', (request, response) => {
+  const song = request.body;
+
+  for (let requiredParameter of ['song_title', 'artist_name', 'genre', 'song_rating']) {
+    if (!song[requiredParameter]) {
+      return response
+        .status(422)
+        .send({ error: `Expected format: { song_title: <String>, artist_name: <String>, genre: <String>, song_rating: <Integer> }. You're missing a "${requiredParameter}" property.` });
+    }
+  }
+
+  database('favorites').where({ id: request.params.id }).update(song, ['id', 'song_title', 'artist_name', 'song_rating'])
+    .then(song => {
+      response.status(200).json({ id: song[0], song_title: song[1], artist_name: song[2], genre: song[3], song_rating: song[4]})
+    })
+    .catch(error => {
+      response.status(500).json({ error });
+    });
+});


### PR DESCRIPTION
## Waffle Card: closes #13

## Type of change:
- [X] New feature
- [] Bug fix
- [] Testing
- [] Update

## Description:

This adds the functionality to update a song. If a song is successfully updated (All fields are required), the song item is returned. If the song is not successfully updated, a 400 status code is returned.

Allows one to update an existing song with the following parameters:

```
{
"songs": {
"id": 1,
"name": "We Are the Champions",
"artist_name": "Queen"
"genre": "Rock",
"song_rating": 77
}
}
```

## Necessary checkmarks:
- [X] Code runs locally
- [N/A] All tests pass
