### PR TITLE
24 seed playlists favorites & playlists favorites am aq

### DIFF
--- a/db/migrations/20181204135444_initial.js
+++ b/db/migrations/20181204135444_initial.js
@@ -9,11 +9,11 @@ exports.up = function(knex, Promise) {
 
         table.timestamps(true, true);
       }),
-  
+
       knex.schema.createTable('playlists', function(table) {
         table.increments('id').primary();
         table.string('name');
-  
+
         table.timestamps(true, true);
       }),
 
@@ -21,17 +21,17 @@ exports.up = function(knex, Promise) {
         table.increments('id').primary();
         table.integer('favorite_id').references('favorites.id');
         table.integer('playlist_id').references('playlists.id');
-  
+
         table.timestamps(true, true);
       })
     ])
   };
-  
-  
+
+
   exports.down = function(knex, Promise) {
     return Promise.all([
+      knex.schema.dropTable('playlists_favorites'),
       knex.schema.dropTable('playlists'),
       knex.schema.dropTable('favorites'),
-      knex.schema.dropTable('playlists_favorites')
     ]);
   }

--- a/db/migrations/20181204135444_initial.js
+++ b/db/migrations/20181204135444_initial.js
@@ -19,8 +19,10 @@ exports.up = function(knex, Promise) {
 
       knex.schema.createTable('playlists_favorites', function(table) {
         table.increments('id').primary();
-        table.integer('favorite_id').references('favorites.id');
-        table.integer('playlist_id').references('playlists.id');
+        table.integer('favorite_id').unsigned();
+        table.integer('playlist_id').unsigned();
+        table.foreign('favorite_id').references('favorites.id');
+        table.foreign('playlist_id').references('playlists.id');
 
         table.timestamps(true, true);
       })

--- a/db/seeds/dev/playlists_favorites.js
+++ b/db/seeds/dev/playlists_favorites.js
@@ -1,10 +1,4 @@
-// pry = require('pryjs')
-// eval(pry.it)
-
-
-
 exports.seed = function(knex, Promise) {
-  // Deletes ALL existing entries
 
   return knex('playlists_favorites').del()
     .then(() => knex('playlists').del())
@@ -13,28 +7,8 @@ exports.seed = function(knex, Promise) {
     .catch(error => console.log(`Error deleting: ${ error }`))
 
     .then(function () {
-
-      const favorites =
-          [{ song_title: 'Roxanne', artist_name: 'The Police', genre: 'Rock', song_rating: '34' },
-          { song_title: 'Cloudy', artist_name: 'Funkmammoth', genre: 'Funk', song_rating: '23' },
-          { song_title: 'No Quarter', artist_name: 'Led Zeppelin', genre: 'Rock', song_rating: '45'}]
-      const playlists = [{name: 'sleep now'}, {name: 'disco'}]
-
-      function makeFavorite(knex, favorite) {
-        return knex('favorites').insert({ song_title: favorite.song_title, artist_name: favorite.artist_name, genre: favorite.genre, song_rating: favorite.song_rating}, 'id');
-      }
-      function makePlaylist(knex, playlist) {
-        return knex('playlists').insert({ name: playlist.name}, 'id');
-      }
-      function makePlaylistsFavorite(knex, favorite_id, playlist_id) {
-        return knex('playlists_favorites').insert({ favorite_id: favorite_id, playlist_id: playlist_id } , 'id');
-      }
-
       return(Promise.all([
 
-        // favorites.forEach(function(favorite) {
-        //   makeFavorite(knex, favorite)
-        // }),
         knex('favorites').insert([
           { song_title: 'Roxanne', artist_name: 'The Police', genre: 'Rock', song_rating: '34' },
           { song_title: 'Cloudy', artist_name: 'Funkmammoth', genre: 'Funk', song_rating: '23' },
@@ -44,43 +18,28 @@ exports.seed = function(knex, Promise) {
           { name: 'sleep now'}, { name: 'disco'}
         ])
       ]))
-      // Inserts seed entries
     })
     .then(function () {
       return knex('favorites').pluck('id').then(function(favoriteIds) {
-        // console.log(favoriteIds)
         var faveIds = favoriteIds
-        // console.log(faveIds)
+
         return knex('playlists').pluck('id').then(function(playlistIds) {
           var playIds = playlistIds
-          // console.log(faveIds)
-          // console.log(playIds)
 
           var fave_play_ids = faveIds.map(function(faveId, index) {
             return [faveId, playIds[Math.floor(Math.random()*playIds.length)] ]
           });
-          console.log(fave_play_ids)
+
           fave_play_ids.forEach(function(fave_play_id) {
-            // console.log(fave_play_id[0])
-            // console.log(fave_play_id[1])
             return Promise.all([knex('playlists_favorites').insert({ favorite_id: fave_play_id[0], playlist_id: fave_play_id[1] })]);
           })
-          // console.log(favyId)
-
         })
-
-        // eval(pry.it)
-        console.log(fave_play_ids)
-        // faveIds.forEach(function(favorite_id) {
-        //
-        //   return knex('playlists_favorites').insert({ favorite_id: favorite_id });
-        // })
       })
     })
     .then(function() {
       return knex('playlists').pluck('id').then(function(ids) {
-        // console.log(ids)
       })
     })
-
+    .then(console.log('Seeded all data.'))
+    .catch(error => console.log(`Error seeding: ${ error }`))
 }

--- a/db/seeds/dev/playlists_favorites.js
+++ b/db/seeds/dev/playlists_favorites.js
@@ -1,9 +1,17 @@
+pry = require('pryjs')
+// eval(pry.it)
+
+
 
 exports.seed = function(knex, Promise) {
   // Deletes ALL existing entries
+
   return knex('playlists_favorites').del()
-    .then(knex('playlists').del())
-    .then(knex('favorites').del())
+    .then(() => knex('playlists').del())
+    .then(() => knex('favorites').del())
+    .then(console.log('Deleted all'))
+    .catch(error => console.log(`Error deleting: ${ error }`))
+
     .then(function () {
 
       const favorites =
@@ -24,16 +32,55 @@ exports.seed = function(knex, Promise) {
 
       return(Promise.all([
 
+        // favorites.forEach(function(favorite) {
+        //   makeFavorite(knex, favorite)
+        // }),
         knex('favorites').insert([
           { song_title: 'Roxanne', artist_name: 'The Police', genre: 'Rock', song_rating: '34' },
           { song_title: 'Cloudy', artist_name: 'Funkmammoth', genre: 'Funk', song_rating: '23' },
           { song_title: 'No Quarter', artist_name: 'Led Zeppelin', genre: 'Rock', song_rating: '45'}
         ]),
-        knex('playlists').insert(
-          [{ name: 'sleep now'}, { name: 'disco'}]
-        )
-
+        knex('playlists').insert([
+          { name: 'sleep now'}, { name: 'disco'}
+        ])
       ]))
       // Inserts seed entries
     })
+    .then(function () {
+      return knex('favorites').pluck('id').then(function(favoriteIds) {
+        console.log(favoriteIds)
+        var faveIds = favoriteIds
+        console.log(faveIds)
+        return knex('playlists').pluck('id').then(function(playlistIds) {
+          var playIds = playlistIds
+          console.log(faveIds)
+          console.log(playIds)
+
+          var fave_play_ids = faveIds.map(function(faveId, index) {
+            return [faveId, playIds[Math.floor(Math.random()*playIds.length)] ]
+          });
+          console.log(fave_play_ids)
+          var favyId = fave_play_ids.forEach(function(fave_play_id) {
+            console.log(fave_play_id[0])
+            console.log(fave_play_id[1])
+            return knex('playlists_favorites').insert({ favorite_id: fave_play_id[0], playlist_id: fave_play_id[1] }, 'id');
+          })
+          console.log(favyId)
+
+        })
+
+        // eval(pry.it)
+        console.log(fave_play_ids)
+        // faveIds.forEach(function(favorite_id) {
+        //
+        //   return knex('playlists_favorites').insert({ favorite_id: favorite_id });
+        // })
+      })
+    })
+    .then(function() {
+      return knex('playlists').pluck('id').then(function(ids) {
+        console.log(ids)
+      })
+    })
+
 }

--- a/db/seeds/dev/playlists_favorites.js
+++ b/db/seeds/dev/playlists_favorites.js
@@ -1,0 +1,39 @@
+
+exports.seed = function(knex, Promise) {
+  // Deletes ALL existing entries
+  return knex('playlists_favorites').del()
+    .then(knex('playlists').del())
+    .then(knex('favorites').del())
+    .then(function () {
+
+      const favorites =
+          [{ song_title: 'Roxanne', artist_name: 'The Police', genre: 'Rock', song_rating: '34' },
+          { song_title: 'Cloudy', artist_name: 'Funkmammoth', genre: 'Funk', song_rating: '23' },
+          { song_title: 'No Quarter', artist_name: 'Led Zeppelin', genre: 'Rock', song_rating: '45'}]
+      const playlists = [{name: 'sleep now'}, {name: 'disco'}]
+
+      function makeFavorite(knex, favorite) {
+        return knex('favorites').insert({ song_title: favorite.song_title, artist_name: favorite.artist_name, genre: favorite.genre, song_rating: favorite.song_rating}, 'id');
+      }
+      function makePlaylist(knex, playlist) {
+        return knex('playlists').insert({ name: playlist.name}, 'id');
+      }
+      function makePlaylistsFavorite(knex, favorite_id, playlist_id) {
+        return knex('playlists_favorites').insert({ favorite_id: favorite_id, playlist_id: playlist_id } , 'id');
+      }
+
+      return(Promise.all([
+
+        knex('favorites').insert([
+          { song_title: 'Roxanne', artist_name: 'The Police', genre: 'Rock', song_rating: '34' },
+          { song_title: 'Cloudy', artist_name: 'Funkmammoth', genre: 'Funk', song_rating: '23' },
+          { song_title: 'No Quarter', artist_name: 'Led Zeppelin', genre: 'Rock', song_rating: '45'}
+        ]),
+        knex('playlists').insert(
+          [{ name: 'sleep now'}, { name: 'disco'}]
+        )
+
+      ]))
+      // Inserts seed entries
+    })
+}

--- a/db/seeds/dev/playlists_favorites.js
+++ b/db/seeds/dev/playlists_favorites.js
@@ -1,4 +1,4 @@
-pry = require('pryjs')
+// pry = require('pryjs')
 // eval(pry.it)
 
 
@@ -48,24 +48,24 @@ exports.seed = function(knex, Promise) {
     })
     .then(function () {
       return knex('favorites').pluck('id').then(function(favoriteIds) {
-        console.log(favoriteIds)
+        // console.log(favoriteIds)
         var faveIds = favoriteIds
-        console.log(faveIds)
+        // console.log(faveIds)
         return knex('playlists').pluck('id').then(function(playlistIds) {
           var playIds = playlistIds
-          console.log(faveIds)
-          console.log(playIds)
+          // console.log(faveIds)
+          // console.log(playIds)
 
           var fave_play_ids = faveIds.map(function(faveId, index) {
             return [faveId, playIds[Math.floor(Math.random()*playIds.length)] ]
           });
           console.log(fave_play_ids)
-          var favyId = fave_play_ids.forEach(function(fave_play_id) {
-            console.log(fave_play_id[0])
-            console.log(fave_play_id[1])
-            return knex('playlists_favorites').insert({ favorite_id: fave_play_id[0], playlist_id: fave_play_id[1] }, 'id');
+          fave_play_ids.forEach(function(fave_play_id) {
+            // console.log(fave_play_id[0])
+            // console.log(fave_play_id[1])
+            return Promise.all([knex('playlists_favorites').insert({ favorite_id: fave_play_id[0], playlist_id: fave_play_id[1] })]);
           })
-          console.log(favyId)
+          // console.log(favyId)
 
         })
 
@@ -79,7 +79,7 @@ exports.seed = function(knex, Promise) {
     })
     .then(function() {
       return knex('playlists').pluck('id').then(function(ids) {
-        console.log(ids)
+        // console.log(ids)
       })
     })
 


### PR DESCRIPTION
## Waffle Card: closes #24

## Type of change:
- [X] New feature
- [X] Bug fix
- [] Testing
- [] Update

## Description:
### New feature
This adds a seed file to seed our favorites, playlists, & playlists favorites data. 

![2018-12-06 seeding result](https://user-images.githubusercontent.com/36902512/49610581-38336580-f95c-11e8-997b-c7b4ea050916.png)

### Bug fix
This also changes the order in which data is rolled back, so that dependent data is removed first. 

## Necessary checkmarks:
- [X] Code runs locally
- [N/A] All tests pass
