### PR TITLE
15 get playlist index endpoint am aq

### DIFF
--- a/server.js
+++ b/server.js
@@ -136,7 +136,7 @@ app.get('/api/v1/playlists', (request, response) => {
         var playlistFavorites = []
 
         const buildPlaylistIndex = () => {
-          for (index = 0; index < uniquePlaylistIds.length; index++) {
+          for (index = 0; index < uniquePlaylistIds.length; index ++) {
 
             playlists.forEach(function(playlist) {
               if (playlist["playlist_id"] === uniquePlaylistIds[index]) {
@@ -150,16 +150,17 @@ app.get('/api/v1/playlists', (request, response) => {
               }
             })
 
-            playlistWithFavorites = { id: uniquePlaylistIds[index][0],
-                                      favorites: playlistFavorites }
+            playlistWithFavorites = { id: uniquePlaylistIds[index],
+                                      playlist_name: uniquePlaylistIds[index + 1],
+                                      songs: playlistFavorites }
             playlistIndex.push(playlistWithFavorites)
+            index++
             playlistFavorites = []
 
           }
         }
         buildPlaylistIndex()
-        response.status(200).json(uniquePlaylistIds)
-        // response.status(200).json(playlists)
+        response.status(200).json(playlistIndex)
       } else {
         response.status(404).json({
           error: `Could not find playlist with id ${request.params.id}`

--- a/server.js
+++ b/server.js
@@ -118,28 +118,28 @@ app.get('/api/v1/playlists', (request, response) => {
     .then(playlists => {
       if (playlists.length) {
 
-        var playlistIds = []
+        var playlistInfo = []
 
         playlists.forEach(function(playlist) {
-          playlistIds.push(playlist["playlist_id"]);
-          playlistIds.push(playlist["name"])
+          playlistInfo.push(playlist["playlist_id"]);
+          playlistInfo.push(playlist["name"]);
         })
 
         const uniqueValues = (value, index, self) => {
           return self.indexOf(value) === index;
         }
 
-        const uniquePlaylistIds = playlistIds.filter(uniqueValues);
+        const uniquePlaylistInfo = playlistInfo.filter(uniqueValues);
 
         var playlistIndex = []
         var eachPlaylistWithFavorites = {}
         var playlistFavorites = []
 
         const buildPlaylistIndex = () => {
-          for (index = 0; index < uniquePlaylistIds.length; index ++) {
+          for (index = 0; index < uniquePlaylistInfo.length; index ++) {
 
             playlists.forEach(function(playlist) {
-              if (playlist["playlist_id"] === uniquePlaylistIds[index]) {
+              if (playlist["playlist_id"] === uniquePlaylistInfo[index]) {
                 playlistFavorites.push({
                   id: playlist["favorite_id"],
                   name: playlist["song_title"],
@@ -150,8 +150,8 @@ app.get('/api/v1/playlists', (request, response) => {
               }
             })
 
-            playlistWithFavorites = { id: uniquePlaylistIds[index],
-                                      playlist_name: uniquePlaylistIds[index + 1],
+            playlistWithFavorites = { id: uniquePlaylistInfo[index],
+                                      playlist_name: uniquePlaylistInfo[index + 1],
                                       songs: playlistFavorites }
             playlistIndex.push(playlistWithFavorites)
             index++

--- a/server.js
+++ b/server.js
@@ -118,36 +118,48 @@ app.get('/api/v1/playlists', (request, response) => {
     .then(playlists => {
       if (playlists.length) {
 
-        var playIds = []
+        var playlistIds = []
+
         playlists.forEach(function(playlist) {
-          playIds.push(playlist["playlist_id"])
+          playlistIds.push(playlist["playlist_id"]);
+          playlistIds.push(playlist["name"])
         })
-        const distinct = (value, index, self) => {
+
+        const uniqueValues = (value, index, self) => {
           return self.indexOf(value) === index;
         }
-        const uniquePlayIds = playIds.filter(distinct);
 
-        var finalArr = []
-        var finalEl = {}
-        var faveEl = []
-        const final = () => {
-          for (i =0; i < uniquePlayIds.length; i++) {
-            playlists.map(function(p, index) {
-              if (p["playlist_id"] === uniquePlayIds[i]) {
-                faveEl.push({song_title: p["song_title"],
-                                  artist_name: p["artist_name"],
-                                  genre: p["genre"],
-                                  song_rating: p["song_rating"]
-                                })
+        const uniquePlaylistIds = playlistIds.filter(uniqueValues);
+
+        var playlistIndex = []
+        var eachPlaylistWithFavorites = {}
+        var playlistFavorites = []
+
+        const buildPlaylistIndex = () => {
+          for (index = 0; index < uniquePlaylistIds.length; index++) {
+
+            playlists.forEach(function(playlist) {
+              if (playlist["playlist_id"] === uniquePlaylistIds[index]) {
+                playlistFavorites.push({
+                  id: playlist["favorite_id"],
+                  name: playlist["song_title"],
+                  artist_name: playlist["artist_name"],
+                  genre: playlist["genre"],
+                  song_rating: playlist["song_rating"]
+                })
               }
             })
-            finalEl = {id: uniquePlayIds[i], favorites: faveEl}
-            finalArr.push(finalEl)
-            faveEl = []
+
+            playlistWithFavorites = { id: uniquePlaylistIds[index][0],
+                                      favorites: playlistFavorites }
+            playlistIndex.push(playlistWithFavorites)
+            playlistFavorites = []
+
           }
         }
-        final()
-        response.status(200).json(finalArr)
+        buildPlaylistIndex()
+        response.status(200).json(uniquePlaylistIds)
+        // response.status(200).json(playlists)
       } else {
         response.status(404).json({
           error: `Could not find playlist with id ${request.params.id}`

--- a/server.js
+++ b/server.js
@@ -115,21 +115,67 @@ app.get('/api/v1/playlists', (request, response) => {
     .join('playlists_favorites', {'playlists.id': 'playlists_favorites.playlist_id'} )
     .join('favorites', {'playlists_favorites.favorite_id': 'favorites.id'} )
     .select()
-    .then(query => {
-      if (query.length) {
-        var playlists = query.map(function(p, index) {
-          return { id: p["playlist_id"], name: p["name"], songs: []}
-        })
-        var final = playlists.map(function(play, index) {
-          query.map(function(q, index) {
-            if (play["id"] == q["playlist_id"]) {
-              play["songs"].push({id: q["id"], song_title: q["song_title"]});
-              return play["songs"]
-            }
-          })
-        })
+    .then(playlists => {
+      if (playlists.length) {
+        // var favorites = playlist.map(function(p, index) {
+        //   return { song_title: p["song_title"],
+        //            artist_name: p["artist_name"],
+        //            genre: p["genre"],
+        //            song_rating: p["song_rating"]
+        //          }
+        // })
+        //
+        // response.status(200).json({
+        //   id: playlist[0]["playlist_id"],
+        //   playlist_name: playlist[0]["name"],
+        //   favorites
+        // })
 
-        response.status(200).json(final)
+        var playIds = []
+        playlists.forEach(function(playlist) {
+          playIds.push(playlist["playlist_id"])
+        })
+        const distinct = (value, index, self) => {
+          return self.indexOf(value) === index;
+        }
+        const uniquePlayIds = playIds.filter(distinct);
+
+        // var playArr = []
+        // var playHash = {}
+        // uniquePlayIds.forEach(function(uniqplayid) {
+        //   playHash["id"] = uniqplayid
+        //   playArr.push(playHash)
+        // })
+        // const uniquePlayId.map(function(uniqueplayid) {
+        var finalArr = []
+        var finalEl = ''
+        const final = () => {
+          for (i =0; i < uniquePlayIds.length; i++) {
+
+          //     return { id: uniquePlayIds[i]}
+                var favorites = playlists.map(function(p, index) {
+                  if (p["playlist_id"] === uniquePlayIds[i]) {
+                    finalArr.push({id: uniquePlayIds[i],
+                                   favorites:
+                                            {song_title: p["song_title"],
+                                             artist_name: p["artist_name"],
+                                             genre: p["genre"],
+                                             song_rating: p["song_rating"]
+                                            }
+                                  })
+                  }
+                })
+
+
+
+          }
+        }
+        final()
+        response.status(200).json(
+          // id: playlist[0]["playlist_id"],
+          // playlist_name: playlist[0]["name"],
+          finalArr
+        )
       } else {
         response.status(404).json({
           error: `Could not find playlist with id ${request.params.id}`

--- a/server.js
+++ b/server.js
@@ -107,3 +107,15 @@ app.delete('/api/v1/songs/:id', (request, response) => {
       response.status(404).json({ error });
     });
 });
+
+// GET ALL PLAYLISTS
+
+app.get('/api/v1/playlists', (request, response) => {
+  database('playlists').select()
+    .then((playlists) => {
+      response.status(200).json(playlists)
+    })
+    .catch((error) => {
+      response.status(500).json({ error })
+    })
+})

--- a/server.js
+++ b/server.js
@@ -117,19 +117,6 @@ app.get('/api/v1/playlists', (request, response) => {
     .select()
     .then(playlists => {
       if (playlists.length) {
-        // var favorites = playlist.map(function(p, index) {
-        //   return { song_title: p["song_title"],
-        //            artist_name: p["artist_name"],
-        //            genre: p["genre"],
-        //            song_rating: p["song_rating"]
-        //          }
-        // })
-        //
-        // response.status(200).json({
-        //   id: playlist[0]["playlist_id"],
-        //   playlist_name: playlist[0]["name"],
-        //   favorites
-        // })
 
         var playIds = []
         playlists.forEach(function(playlist) {
@@ -140,42 +127,27 @@ app.get('/api/v1/playlists', (request, response) => {
         }
         const uniquePlayIds = playIds.filter(distinct);
 
-        // var playArr = []
-        // var playHash = {}
-        // uniquePlayIds.forEach(function(uniqplayid) {
-        //   playHash["id"] = uniqplayid
-        //   playArr.push(playHash)
-        // })
-        // const uniquePlayId.map(function(uniqueplayid) {
         var finalArr = []
-        var finalEl = ''
+        var finalEl = {}
+        var faveEl = []
         const final = () => {
           for (i =0; i < uniquePlayIds.length; i++) {
-
-          //     return { id: uniquePlayIds[i]}
-                var favorites = playlists.map(function(p, index) {
-                  if (p["playlist_id"] === uniquePlayIds[i]) {
-                    finalArr.push({id: uniquePlayIds[i],
-                                   favorites:
-                                            {song_title: p["song_title"],
-                                             artist_name: p["artist_name"],
-                                             genre: p["genre"],
-                                             song_rating: p["song_rating"]
-                                            }
-                                  })
-                  }
-                })
-
-
-
+            playlists.map(function(p, index) {
+              if (p["playlist_id"] === uniquePlayIds[i]) {
+                faveEl.push({song_title: p["song_title"],
+                                  artist_name: p["artist_name"],
+                                  genre: p["genre"],
+                                  song_rating: p["song_rating"]
+                                })
+              }
+            })
+            finalEl = {id: uniquePlayIds[i], favorites: faveEl}
+            finalArr.push(finalEl)
+            faveEl = []
           }
         }
         final()
-        response.status(200).json(
-          // id: playlist[0]["playlist_id"],
-          // playlist_name: playlist[0]["name"],
-          finalArr
-        )
+        response.status(200).json(finalArr)
       } else {
         response.status(404).json({
           error: `Could not find playlist with id ${request.params.id}`


### PR DESCRIPTION
## Waffle Card: closes #15

## Type of change:
- [X] New feature
- [] Bug fix
- [] Testing
- [] Update

## Description:
### New feature
`GET /api/v1/playlists`
This branch adds a playlist index endpoint, which returns all the playlists in the database along with their associated songs.

If successful, this request returns a response in the following format:
```
[
    {
        "id": 1,
        "playlist_name": "Favorite songs of all time",
        "songs": [
          {
            "id": 1,
            "name": "We Will Rock You",
            "artist_name": "Queen"
            "genre": "Rock",
            "song_rating": 88
          },
          {
            "id": 2,
            "name": "Careless Whisper",
            "artist_name": "George Michael"
            "genre": "Pop",
            "song_rating": 93
          }
        ]
    },
    {
        "id": 2,
        "name": "Other amazing songs",
        "songs": [
          {
            "id": 1,
            "name": "We Will Rock You",
            "artist_name": "Queen"
            "genre": "Rock",
            "song_rating": 88
          },
          {
            "id": 2,
            "name": "Careless Whisper",
            "artist_name": "George Michael"
            "genre": "Pop",
            "song_rating": 93
          },
        ]
    },
]
```
## Necessary checkmarks:
- [X] Code runs locally
- [N/A] All tests pass
